### PR TITLE
Small fixes (spelling, typo, grammatical)

### DIFF
--- a/joss/paper.md
+++ b/joss/paper.md
@@ -30,7 +30,7 @@ Materials science research deals primarily with understanding the relationship
 between the structure and properties of materials. With recent advances in
 computational power and automation of simulation techniques, material structure
 and property databases have emerged [@Jain2013; @Kirklin2015; @Curtarolo2012],
-allowing a more data-driven approach to carrying out materials research.  Recent
+allowing a more data-driven approach to carrying out materials research. Recent
 studies have demonstrated that representing these databases as material networks
 can enable extraction of new materials knowledge [@Hegde2018; @Isayev2015] or
 help tackle challenges like predictive synthesis [@Aykol2019a], which require
@@ -38,7 +38,7 @@ relational information between materials. Materials databases have become very
 popular because they enable their users to do rapid prototyping by searching
 near globally for figures of merit for their target application. However, both
 scientists and engineers have little in the way of visualization of aggregates
-from these databases, i.e., intuitive layouts that help understand which
+from these databases, that is, intuitive layouts that help understand which
 materials are related and how they are related. The need for a tool that does
 this is particularly crucial in materials science because properties like phase
 stability and crystal structure similarity are themselves functions of a
@@ -47,7 +47,7 @@ material dataset, rather than of individual materials.
 In these new approaches, materials can be represented with a graph structure
 that has *nodes* standing in for materials, and *links* between them encoding
 the appropriate relationships of interest, such as thermodynamic co-existence,
-chemical similarity or co-occurence in text, to name a few. **MaterialNet** is
+chemical similarity or co-occurrence in text, to name a few. **MaterialNet** is
 an open-source web application designed to explore the topology of such material
 networks, while also displaying information about each material, highlighting
 its immediate neighborhood within the graph, and offering several auxiliary
@@ -58,7 +58,7 @@ contains on the order of 20,000 materials, with on the order of 200,000 links
 between them [@Aykol2019a]. Large graphs of this sort demand *interactive
 visualization*, empowering materials researchers to explore the data, a key user
 requirement highlighted by field experts [@Aykol2019b].  To the best of our
-knowledge, there exist no other interactive visualization tool for materials
+knowledge, there exists no other interactive visualization tool for materials
 networks.  MaterialNet provides interactive "maps" of the materials space
 exposed in large material databases, helping researchers navigate this space
 with a particular research task in mind, as showcased in
@@ -67,7 +67,7 @@ http://maps.matr.io/.
 
 ![**MaterialNet displaying the local network environment of a target material.**
 The main material selected, LiOsO<sub>3</sub>, is hypothetical (i.e., a
-computational discovery) and is therefore labeled "undiscovered." A well-known
+computational discovery) and is therefore labeled "undiscovered". A well-known
 material, Li<sub>2</sub>O, that exists in the vicinity of this target
 material is also added to the displayed subgraph. Node sizes represent the node
 degree (i.e. the number of links) for each material.](fig1.png)
@@ -80,32 +80,32 @@ MaterialNet uses [GeoJS](https://opengeoscience.github.io/geojs/) [@geojs], an
 open-source mapping library developed by Kitware, to provide a highly
 interactive, attractive rendering of a node-link diagram representing the graph.
 Nodes in the graph are displayed with a color, encoding a data value carried on
-it (such as its year of discovery, or its formation energy), and with a specific
-size, encoding some other data value (such as its degree of connectivity within
+it (e.g. year of discovery, formation energy), and with a specific
+size, encoding some other data value (e.g. degree of connectivity within
 the graph). Layout software such as Gephi provides an initial configuration of
 the nodes in the graph, and MaterialNet has its own dynamic,
 force-based layout mode as well. The GeoJS node-link diagram is equipped
 with standard mouse gestures to enable interactive exploration: for example, by
 clicking on a node, that material's data appears in a panel on-screen, and its
 one-hop neighborhood is highlighted in the graph view. Such nodes may also be
-"pinned," leaving them visible in a list while other actions are performed. They
+"pinned", leaving them visible in a list while other actions are performed. They
 can also be made part of a chemical subspace, which selects out all materials
 containing one of several chemical elements. Additionally, MaterialNet can
 dynamically reconfigure the layout of these subgraphs, using a force-based
 simulation to bring related nodes closer together, providing a more organic
 sense of continuity and structure.
 
-## Searching, Fitering, and Chemical Subspaces
+## Searching, Filtering, and Chemical Subspaces
 
 Effective, contextual search and filtering of materials (e.g. by using chemical
 formulas, constraining to chemical spaces, filtering based on material
-properties, historical material data etc.) are essential for this visualization
+properties, historical material data) are essential for this visualization
 tool to be useful for the researchers.  For this purpose, MaterialNet includes a
 simple search bar that can be used to find materials by their chemical makeup.
 Once a material of interest is found, it can be "pinned" to keep it in a
-special, persistent group of materials, allowing for exploration of its own
+special, persistent group of materials, allowing for exploration of its
 graph neighborhood, of the materials spanned by its chemical subspace, or of
-materials found via fresh searches. MaterialNet also allows for filtering the
+materials found via fresh searches. MaterialNet allows filtering the
 available materials by setting ranges on data values such as formation energy.
 These methods enable the researcher to winnow out unrelated materials while
 building up a specific group of interest, allowing for a focus on the smaller
@@ -125,7 +125,7 @@ external materials databases such as the [OQMD](http://oqmd.org).
 MaterialNet incorporates [LineUp](https://github.com/lineupjs) [@Gratzl2013], an open-source
 tabular data visualization system developed in a collaboration between Kitware
 and Harvard University. LineUp displays all of the materials in the currently
-selected subgraph, and allows for interactive sorting of those materials using
+selected subgraph and allows interactive sorting of those materials using
 custom weighting functions. This tabulation system also allows the researcher to
 select materials directly from its table view, focusing them in the graph view.
 Combining the two visualization modes and linking them in this way enables


### PR DESCRIPTION
I made several small changes to the document. 

* L41: i.e. should not be used in a sentence
* L50: Fixed typo `co-occurence` → `co-occurrence`.
* L61: Fixed grammatical error `there exist` → `there exists`
* L70: Moved period outside quote `"undiscovered."` → `"undiscovered".`
* L83: Change wordy phrasing `(such as ...)` → `(e.g. ...)`
* L84: Change wordy phrasing `(such as ...)` → `(e.g. ...)`
* L91: Moved comma outside quote
* L98: Fixed typo in title `Fitering` → `Filtering`
* L102: Removed `, etc.`, since `e.g.` is already used
* L106: Removed redundant word `own`.
* L108: Removed wordy words: `MaterialNet also allows for filtering` →  `MaterialNet allows filtering`
* L128: Removed wordy words: `and allows for interactive sorting` →  `and allows interactive sorting`