### PR TITLE
Enable app to behave differently for different data bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,30 +41,47 @@ Setup
     yarn install
     ```
 
-2. Create sample data directory:
+2. Move into the public assets directory:
 
     ```
-    mkdir public/sample-data
+    cd public
     ```
-3. Unpackage sample data with your preferred tool. Example:
+    
+3. Download the public sample data:
 
     ```
-    tar -xf <SAMPLE_DATA>.tar.gz
+    curl -O -J https://data.kitware.com/api/v1/item/5e5696b4af2e2eed35da2e42/download
+    ```
+    
+    (Alternatively, you can visit the cloud folder where this file is stored at
+    https://data.kitware.com/#collection/5e569610af2e2eed35da2e0b/folder/5e5696acaf2e2eed35da2e33
+    and download the file manually.)
+    
+4. Unpackage the sample data:
+
+    ```
+    tar xzvf sample-data.tar.gz
     ```
 
-    After this step, the `public/sample-data` directory should look something like this:
+    After this step, there will be a `public/sample-data` directory with
+    contents like this:
 
     ```
     stability.json
-    cooccurrence-1k.json
-    cooccurrence-500k.json
+    similarity.json
+    control.json
     structures/
     ```
+    
+5. Build and serve the application:
 
+    ```
+    BROWSER=none yarn start
+    ```
 
-Once these steps are completed, reloading the page in your browser should render the chosen sample dataset.
-
-
+6. Launch the application: visit http://localhost:3000 in your browser, and wait
+   a few moments for the initial dataset to load (the data is pretty big, so
+   this could take up to 10 seconds).
 
 Interactions
 ------------

--- a/src/components/graph-vis/controls.js
+++ b/src/components/graph-vis/controls.js
@@ -29,6 +29,8 @@ import RotatedPin from './RotatedPin';
 import { faProjectDiagram, faFlask } from '@fortawesome/free-solid-svg-icons';
 import * as panels from './helpPanel';
 
+import { fetchJSON } from '../../rest';
+
 function simplify(label) {
   // simplify the label for better values
   return deburr(label).replace(/[ ,.<>/|\\[]{}-_=+()*&^%$#@!~\t\n\r]+/gm, '');
@@ -75,6 +77,15 @@ class Controls extends React.Component {
         <FontAwesomeIcon icon={faFlask} />
       </IconButton>
     </>;
+  }
+
+  async componentDidMount() {
+    const store = this.context;
+
+    // Restrict available datasets by what is specified in the data bundle
+    // control file.
+    const control = await fetchJSON('sample-data/control.json')
+    store.datasets = store.datasets.filter((d) => control.includes(d.key));
   }
 
   render() {

--- a/src/datasets/index.js
+++ b/src/datasets/index.js
@@ -5,21 +5,25 @@ import cooccurence from './cooccurence';
 
 export default [
     {
+        key: 'stability',
         label: 'Materials Stability Network',
         fileName: './sample-data/stability.json',
         ...precise
     },
     {
+        key: 'co1k',
         label: 'Materials Co-occurrence Network (~1000 edges)',
         fileName: './sample-data/cooccurrence-1k.json',
         ...cooccurence
     },
     {
+        key: 'co500k',
         label: 'Materials Co-occurrence Network (~500000 edges)',
         fileName: './sample-data/cooccurrence-500k.json',
         ...cooccurence
     },
     {
+        key: 'similarity',
         label: 'Materials Similarity Network',
         fileName: './sample-data/similarity.json',
         ...similarity

--- a/src/rest/index.js
+++ b/src/rest/index.js
@@ -1,3 +1,18 @@
+export function fetchJSON (path) {
+  return fetch(path)
+    .then(async res => {
+      const text = await res.text();
+      let json;
+      try {
+        json = JSON.parse(text);
+      } catch (e) {
+        json = null;
+      }
+
+      return json;
+    });
+}
+
 export function fetchStructure(name) {
   return fetch(`sample-data/structures/${name}.cjson`)
     .then(async res => {

--- a/src/rest/index.js
+++ b/src/rest/index.js
@@ -14,16 +14,5 @@ export function fetchJSON (path) {
 }
 
 export function fetchStructure(name) {
-  return fetch(`sample-data/structures/${name}.cjson`)
-    .then(async res => {
-      const text = await res.text();
-      let json;
-      try {
-        json = JSON.parse(text);
-      } catch (e) {
-        json = null;
-      }
-
-      return json;
-    });
+  return fetchJSON(`sample-data/structures/${name}.cjson`);
 }


### PR DESCRIPTION
This PR adds functionality to the app to work for the private data bundles we have been using to deploy MaterialNet to maps.matr.io, and also with a new public data bundle that can be used to build the app locally, anywhere.

Closes #167 