### PR TITLE
Bibliography capitalization/formatting improvements

### DIFF
--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -60,7 +60,7 @@ author = {Hegde, Vinay I. and Aykol, Muratahan and Kirklin, Scott and Wolverton,
 eprint = {1808.10869},
 month = {aug},
 title = {{The phase diagram of all inorganic materials}},
-url = {https://arxiv.org/abs/1808.10869 http://arxiv.org/abs/1808.10869},
+url = {https://arxiv.org/abs/1808.10869},
 year = {2018}
 }
 

--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -8,7 +8,7 @@ month = {dec},
 number = {1},
 pages = {15010},
 publisher = {Nature Publishing Group},
-title = {{The Open Quantum Materials Database (OQMD): assessing the accuracy of DFT formation energies}},
+title = {{The Open Quantum Materials Database (OQMD): Assessing the accuracy of DFT formation energies}},
 url = {http://www.nature.com/articles/npjcompumats201510},
 volume = {1},
 year = {2015}
@@ -59,7 +59,7 @@ arxivId = {1808.10869},
 author = {Hegde, Vinay I. and Aykol, Muratahan and Kirklin, Scott and Wolverton, Christopher},
 eprint = {1808.10869},
 month = {aug},
-title = {{The Phase Diagram of all Inorganic Materials}},
+title = {{The phase diagram of all inorganic materials}},
 url = {https://arxiv.org/abs/1808.10869 http://arxiv.org/abs/1808.10869},
 year = {2018}
 }
@@ -72,7 +72,7 @@ journal = {Matter},
 month = {dec},
 number = {6},
 pages = {1433--1438},
-title = {{The Materials Research Platform: Defining the Requirements from User Stories}},
+title = {{The Materials Research Platform: Defining the requirements from user stories}},
 url = {https://doi.org/10.1016/j.matt.2019.10.024 https://linkinghub.elsevier.com/retrieve/pii/S2590238519302942},
 volume = {1},
 year = {2019}
@@ -86,7 +86,7 @@ issn = {0897-4756},
 journal = {Chemistry of Materials},
 month = {feb},
 number = {3},
-title = {{Materials Cartography: Representing and Mining Materials Space Using Structural and Electronic Fingerprints}},
+title = {{Materials Cartography: Representing and mining materials space using structural and electronic fingerprints}},
 url = {http://pubs.acs.org/doi/10.1021/cm503507h https://pubs.acs.org/doi/10.1021/cm503507h},
 volume = {27},
 year = {2015}
@@ -102,7 +102,7 @@ year = {2015}
 
 @misc{vtkjs,
   author = "Sebastien Jourdain and Ken Martin and Will Schroeder",
-  title = "{v}tk.js: the {Visualization Toolkit on the Web}",
+  title = "{v}tk.js: the {Visualization Toolkit on the web}",
   month = "Oct",
   year = "2017",
   howpublished = "https://blog.kitware.com/vtk-js-the-visualization-toolkit-on-the-web/",
@@ -119,7 +119,7 @@ year = {2015}
 }
 
 @article{ward2017,
-  title = {Including crystal structure attributes in machine learning models of formation energies via Voronoi tessellations},
+  title = {{Including crystal structure attributes in machine learning models of formation energies via Voronoi tessellations}},
   author = {Ward, Logan and Liu, Ruoqian and Krishna, Amar and Hegde, Vinay I. and Agrawal, Ankit and Choudhary, Alok and Wolverton, Chris},
   journal = {Phys. Rev. B},
   volume = {96},


### PR DESCRIPTION
@danielskatz, I tried to standardize how titles are capitalized.

One journal name, "npj Computational Materials", looked strange to me, but the unusual lowercasing seems to be how they cite the name of this journal in the wild: https://www.nature.com/articles/npjcompumats201510.

I will merge this pull request without review in order to generate the galley proof, but please let me know if you have any advice for the stuff you're seeing in this changeset.